### PR TITLE
Fallback user

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/MethodLength:
+  Max: 11
+
 Rails/Date:
   Enabled: false
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -44,6 +44,7 @@ class AssignmentsController < ApplicationController
     @assignments = @current_user.assignments.upcoming.order :start_date
     @current_assignment = Assignment.current
     @switchover_hour = CONFIG[:switchover_hour]
+    @fallback_user = User.fallback
   end
 
   def new

--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -19,6 +19,10 @@ class TwilioController < ApplicationController
   private
 
   def set_on_call_user
-    @user = Assignment.current.user
+    assignment = Assignment.current
+    @user = if assignment.present?
+              assignment.user
+            else User.fallback
+            end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
 
   def index
     @users = User.all
+    @no_fallback = User.fallback.nil?
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ActiveRecord::Base
   validates :phone,
             format: { with: /\+1\d{10}/,
                       message: 'must be 1+ followed by 10 digits' }
+  validates :is_fallback,
+            uniqueness: true,
+            if: -> { is_fallback }
 
   def full_name
     "#{first_name} #{last_name}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ActiveRecord::Base
             format: { with: /\+1\d{10}/,
                       message: 'must be 1+ followed by 10 digits' }
   validates :is_fallback,
-            uniqueness: true,
+            uniqueness: { message: 'may be true for only one user' },
             if: -> { is_fallback }
 
   def full_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,8 @@ class User < ActiveRecord::Base
   def proper_name
     "#{last_name}, #{first_name}"
   end
+
+  def self.fallback
+    User.find_by is_fallback: true
+  end
 end

--- a/app/views/assignments/_current.haml
+++ b/app/views/assignments/_current.haml
@@ -2,5 +2,9 @@
   - if @current_assignment.present?
     %h3.slightly-green Currently on call: #{@current_assignment.user.last_name}
   - else
-    %h3.slightly-red No one currently on call!
+    %h3.slightly-red
+      No one is currently on call!
+      - if @fallback_user.present?
+        #{@fallback_user.last_name} is the fallback.
+
   On-call switches at: #{HOURS[@switchover_hour]}

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -11,4 +11,6 @@
   = f.text_field :email, size: 30
   = f.label :phone
   = f.text_field :phone
+  = f.label :is_fallback, 'Fallback?'
+  = f.check_box :is_fallback
   = f.submit 'Save'

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -10,7 +10,10 @@
     %th
   - @users.each do |user|
     %tr
-      %td= user.full_name
+      %td
+        = user.full_name
+        - if user.is_fallback?
+          (fallback)
       %td= user.spire
       %td= user.email
       %td= user.phone

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -21,3 +21,5 @@
       %td= button_to 'Destroy', user_path(user), method: :delete
   %tr
     %td{ colspan: 6 }= link_to 'Add user', new_user_path
+- if @no_fallback
+  %h3.slightly-red No fallback user!

--- a/app/views/users/new.haml
+++ b/app/views/users/new.haml
@@ -11,4 +11,6 @@
   = f.text_field :email, size: 30
   = f.label :phone
   = f.text_field :phone
+  = f.label :is_fallback, 'Fallback?'
+  = f.check_box :is_fallback
   = f.submit 'Save'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      user:
+        is_fallback: Fallback

--- a/db/migrate/20151204222251_add_is_fallbackto_users.rb
+++ b/db/migrate/20151204222251_add_is_fallbackto_users.rb
@@ -1,0 +1,5 @@
+class AddIsFallbacktoUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :is_fallback, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150909204524) do
+ActiveRecord::Schema.define(version: 20151204222251) do
 
   create_table "assignments", force: :cascade do |t|
     t.integer  "user_id",    limit: 4
@@ -22,13 +22,14 @@ ActiveRecord::Schema.define(version: 20150909204524) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name", limit: 255
-    t.string   "last_name",  limit: 255
-    t.string   "spire",      limit: 255
-    t.string   "email",      limit: 255
-    t.string   "phone",      limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "first_name",  limit: 255
+    t.string   "last_name",   limit: 255
+    t.string   "spire",       limit: 255
+    t.string   "email",       limit: 255
+    t.string   "phone",       limit: 255
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.boolean  "is_fallback",             default: false
   end
 
 end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -162,6 +162,12 @@ describe AssignmentsController do
         submit
         expect(assigns.fetch :switchover_hour).to eql 12
       end
+      it 'includes a variable of the fallback user' do
+        fallback = create :user
+        expect(User).to receive(:fallback).and_return fallback
+        submit
+        expect(assigns.fetch :fallback_user).to eql fallback
+      end
       it 'renders the correct template' do
         submit
         expect(response).to render_template :index

--- a/spec/controllers/twilio_controller_spec.rb
+++ b/spec/controllers/twilio_controller_spec.rb
@@ -2,47 +2,95 @@ require 'rails_helper'
 
 describe TwilioController do
   describe 'GET #call, XML' do
-    before :each do
-      @user = create :user
-      expect(Assignment)
-        .to receive(:current)
-        .and_return(create :assignment, user: @user)
-    end
     let :submit do
       get :call, format: :xml
     end
-    it 'sets the current on call user to the user variable' do
-      submit
-      expect(assigns.fetch :user).to eql @user
+    context 'current assignment is present' do
+      before :each do
+        @user = create :user
+        expect(Assignment)
+          .to receive(:current)
+          .and_return(create :assignment, user: @user)
+      end
+      it 'sets the current on call user to the user variable' do
+        submit
+        expect(assigns.fetch :user).to eql @user
+      end
+      it 'renders the call template' do
+        submit
+        expect(response).to render_template :call
+      end
     end
-    it 'renders the call template' do
-      submit
-      expect(response).to render_template :call
+    context 'no current assignment' do
+      before :each do
+        @user = create :user
+        expect(Assignment)
+          .to receive(:current)
+          .and_return nil
+        expect(User)
+          .to receive(:fallback)
+          .and_return @user
+      end
+      it 'sets the fallback user to the user variable' do
+        submit
+        expect(assigns.fetch :user).to eql @user
+      end
+      it 'renders the call template' do
+        submit
+        expect(response).to render_template :call
+      end
     end
   end
 
   describe 'GET #text, XML' do
     before :each do
-      @user = create :user
-      expect(Assignment)
-        .to receive(:current)
-        .and_return(create :assignment, user: @user)
       @body = 'message body'
     end
     let :submit do
       get :text, format: :xml, Body: @body
     end
-    it 'sets the current on call user to the user variable' do
-      submit
-      expect(assigns.fetch :user).to eql @user
+    context 'current assignment is present' do
+      before :each do
+        @user = create :user
+        expect(Assignment)
+          .to receive(:current)
+          .and_return(create :assignment, user: @user)
+      end
+      it 'sets the current on call user to the user variable' do
+        submit
+        expect(assigns.fetch :user).to eql @user
+      end
+      it 'passes the Body parameter through as a body instance variable' do
+        submit
+        expect(assigns.fetch :body).to eql @body
+      end
+      it 'renders the text template' do
+        submit
+        expect(response).to render_template :text
+      end
     end
-    it 'passes the Body parameter through as a body instance variable' do
-      submit
-      expect(assigns.fetch :body).to eql @body
-    end
-    it 'renders the text template' do
-      submit
-      expect(response).to render_template :text
+    context 'no current assignment' do
+      before :each do
+        @user = create :user
+        expect(Assignment)
+          .to receive(:current)
+          .and_return nil
+        expect(User)
+          .to receive(:fallback)
+          .and_return @user
+      end
+      it 'sets the fallback user to the user variable' do
+        submit
+        expect(assigns.fetch :user).to eql @user
+      end
+      it 'passes the Body parameter through as a body instance variable' do
+        submit
+        expect(assigns.fetch :body).to eql @body
+      end
+      it 'renders the text template' do
+        submit
+        expect(response).to render_template :text
+      end
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -96,6 +96,16 @@ describe UsersController do
       submit
       expect(assigns.fetch :users).to include user_1, user_2, user_3
     end
+    it 'populates no_fallback as true if there is no fallback user' do
+      expect(User).to receive(:fallback).and_return nil
+      submit
+      expect(assigns.fetch :no_fallback).to eql true
+    end
+    it 'populates no_fallback as false if there is a fallback user' do
+      expect(User).to receive(:fallback).and_return "anything that isn't nil"
+      submit
+      expect(assigns.fetch :no_fallback).to eql false
+    end
     it 'renders the index template' do
       submit
       expect(response).to render_template :index

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,9 @@ describe User do
       expect { create :user, is_fallback: true }
         .not_to raise_error
       expect { create :user, is_fallback: true }
-        .to raise_error(ActiveRecord::RecordInvalid)
+        .to raise_error(ActiveRecord::RecordInvalid,
+                        'Validation failed: ' \
+                        'Fallback may be true for only one user')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,4 +14,12 @@ describe User do
         .to eql [user.last_name, user.first_name].join(', ')
     end
   end
+  describe 'validations' do
+    it 'allows only one fallback user' do
+      expect { create :user, is_fallback: true }
+        .not_to raise_error
+      expect { create :user, is_fallback: true }
+        .to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe User do
+  describe 'validations' do
+    it 'allows only one fallback user' do
+      expect { create :user, is_fallback: true }
+        .not_to raise_error
+      expect { create :user, is_fallback: true }
+        .to raise_error(ActiveRecord::RecordInvalid,
+                        'Validation failed: ' \
+                        'Fallback may be true for only one user')
+    end
+  end
   describe 'full_name' do
     it 'returns first name followed by last name' do
       user = create :user
@@ -14,14 +24,13 @@ describe User do
         .to eql [user.last_name, user.first_name].join(', ')
     end
   end
-  describe 'validations' do
-    it 'allows only one fallback user' do
-      expect { create :user, is_fallback: true }
-        .not_to raise_error
-      expect { create :user, is_fallback: true }
-        .to raise_error(ActiveRecord::RecordInvalid,
-                        'Validation failed: ' \
-                        'Fallback may be true for only one user')
+  describe 'self.fallback' do
+    it 'returns the fallback user if one is present' do
+      fallback = create :user, is_fallback: true
+      expect(User.fallback).to eql fallback
+    end
+    it 'returns nil if no fallback user is present' do
+      expect(User.fallback).to eql nil
     end
   end
 end


### PR DESCRIPTION
Closes #9.

Allowing us to specify a fallback user for if if in case no one is on call.
Only one fallback user may be specified.
Incoming calls or texts are redirected to the fallback user if no one is currently on call.
The calendar shows who this is (when there's no one on call).
The users index also shows who this is.