### PR TITLE
Refuse coverage percentage drops

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ SimpleCov.start 'rails'
 SimpleCov.start do
   add_filter '/config/'
   add_filter '/spec/'
+  refuse_coverage_drop
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This will produce failure messages locally, but the most important
consequence will be Travis builds failing outright.