### PR TITLE
Disable IT-fallback now that the Twilio number's set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,17 +21,18 @@ group :production do
 end
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'capistrano', require: false
   gem 'capistrano-bundler', require: false
   gem 'capistrano-passenger', require: false
   gem 'capistrano-pending', require: false
   gem 'capistrano-rails', require: false
+  gem 'listen', '~> 3.0'
   gem 'rb-readline', require: false
 end
 
 group :development, :test do
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'codeclimate-test-reporter', '~> 1.0'
   gem 'haml_lint'
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
+    ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     haml (5.0.1)
@@ -121,6 +122,10 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.1.0)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -187,6 +192,9 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rb-readline (0.5.4)
     request_store (1.3.2)
     rspec (3.6.0)
@@ -220,6 +228,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    ruby_dep (1.5.0)
     ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
     sass (3.4.24)
@@ -289,6 +298,7 @@ DEPENDENCIES
   haml_lint
   jquery-rails
   jquery-ui-rails
+  listen (~> 3.0)
   mocha
   mysql2
   paper_trail

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,10 +18,6 @@ Rails.application.routes.draw do
     get 'twilio/text', to: 'twilio#text', as: :twilio_text
   end
 
-  # Temporary, remove when IT twilio number is fixed:
-  get 'twilio/call', to: 'twilio#call', defaults: {roster_id: 1}
-  get 'twilio/text', to: 'twilio#text', defaults: {roster_id: 1}
-
   get 'changes/:id/undo', to: 'changes#undo', as: :undo_change
   
   unless Rails.env.production?


### PR DESCRIPTION
Closes #81

Also, added the 'listen' gem, otherwise I couldn't check routes.