### PR TITLE
Don't forward SSH agent

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@ lock '3.8.1'
 
 set :application, 'screaming_dinosaur'
 
-set :repo_url, 'git@github.com:umts/screaming-dinosaur.git'
+set :repo_url, 'https://github.com/umts/screaming-dinosaur.git'
 set :branch, :master
 
 set :keep_releases, 5

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 remote_user = Net::SSH::Config.for('af-transit-app3.admin.umass.edu')[:user] || ENV['USER']
 server 'af-transit-app3.admin.umass.edu',
        roles: %w(app db web),
-       user: remote_user
+       user: remote_user,
+       ssh_options: { forward_agent: false }
 set :bundle_env_variables, { 'NOKOGIRI_USE_SYSTEM_LIBRARIES' => 1 }
-set :tmp_dir, "/tmp/#{remote_user}"


### PR DESCRIPTION
If we use a https repo url with a public repo, then we don't need it at
all. This way we can avoid agent forwarding which has a (theoretical)
security implication.