### PR TITLE
This was _technically_ working before

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,5 @@
+env 'PATH', '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
 every :day, at: '9:00am' do
   runner 'Assignment.send_reminders!'
 end


### PR DESCRIPTION
Because jobapps already had this fix, and 'j' comes before 's'.