### PR TITLE
Travis insists that you dont have to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ addons:
   chrome: stable
 env:
   - 'CODECLIMATE_REPO_TOKEN=029db8a4d83b74b2b01b09670c9a28a9c353175415b61186e87a1d70fe461931 RAILS_ENV=test'
-before_install:
-  - gem update --system
-  - gem install bundler
 before_script:
   - cp config/application.yml.example config/application.yml
   - cp config/database.yml.example config/database.yml


### PR DESCRIPTION
That it should "just work" if your gemfile has the "Bundled With" line.
With the release of RubyGems 3.1, `gem update --system` also tries to
install bundler and waits for your OK before overwriting the gem binary.