### PR TITLE
Fix fallback user select box

### DIFF
--- a/app/views/rosters/edit.haml
+++ b/app/views/rosters/edit.haml
@@ -6,9 +6,7 @@
     = f.text_field :name, class: 'form-control'
   .form-group
     = f.label :fallback_user
-    .vert-center
-      = f.select :fallback_user_id,
-        options_from_collection_for_select(@users, :id, :last_name),
-       {}, class: 'form-control custom-select'
+    = f.collection_select :fallback_user_id, @users, :id, :last_name,
+      { include_blank: true }, class: 'form-control custom-select'
   .form-group
     = f.submit 'Save', class: 'btn btn-primary'


### PR DESCRIPTION
@sherson noticed this today
 
1. It didn't have the selected value available to it, so editing a roster always selected the alphabetically first user. Fixed by using the form_for helper.
2. Fallback user is optional in the model, but there was no blank option.