### PR TITLE
Two fixes for compiling assets in production

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-%w[setup deploy scm/git pending bundler rails passenger]
+%w[setup deploy scm/git pending bundler rails passenger yarn]
   .each { |r| require "capistrano/#{r}" }
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'rails', '~> 7.0.4'
 gem 'sassc-rails'
 gem 'snappconfig'
 gem 'sprockets-rails'
-gem 'uglifier'
+gem 'terser'
 gem 'whenever', require: false
 
 group :production do
@@ -33,6 +33,7 @@ group :development do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-pending', require: false
   gem 'capistrano-rails', require: false
+  gem 'capistrano-yarn', require: false
   gem 'ed25519', '>= 1.2', '< 2.0', require: false
   gem 'listen', '~> 3.0'
   gem 'rb-readline', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-yarn (2.0.2)
+      capistrano (~> 3.0)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -335,14 +337,14 @@ GEM
       net-ssh (>= 2.8.0)
     sysexits (1.2.0)
     temple (0.8.2)
+    terser (1.1.12)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.4)
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     umts-custom-matchers (2.0.0)
       rspec-rails (>= 3.0, <= 6.0)
     unicode-display_width (2.0.0)
@@ -374,6 +376,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-pending
   capistrano-rails
+  capistrano-yarn
   capybara
   ed25519 (>= 1.2, < 2.0)
   exception_notification
@@ -403,8 +406,8 @@ DEPENDENCIES
   simplecov
   snappconfig
   sprockets-rails
+  terser
   timecop
-  uglifier
   umts-custom-matchers
   webdrivers
   whenever

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
1. Rails 7 no longer automatically runs `yarn` when precompiling assets. Wasn't mentioned in the release notes, but see rails/rails#43641. Hello again, my friend, `capistrano-yarn`.
2. Uglifier was failing on a `const`... somewhere. I really have no idea where. Uglifier themselves say to use `terser` if you want ES6 support, so...