### PR TITLE
Check login user for subsidiary account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,7 @@
 class ApplicationController < ActionController::Base
   attr_accessor :current_user
 
-  before_action :check_primary_account
-  before_action :set_current_user, :set_roster, :set_paper_trail_whodunnit
+  before_action :check_primary_account, :set_current_user, :set_roster, :set_paper_trail_whodunnit
 
   def confirm_change(object, message = nil)
     change = object.versions.where(whodunnit: @current_user).last

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   attr_accessor :current_user
 
+  before_action :check_primary_account
   before_action :set_current_user, :set_roster, :set_paper_trail_whodunnit
 
   def confirm_change(object, message = nil)
@@ -63,4 +64,12 @@ class ApplicationController < ActionController::Base
     @roster ||= Roster.first
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
+
+  def check_primary_account
+    return if request.env['UMAPrimaryAccount'] == request.env['uid']
+
+    @primary_account = request.env['UMAPrimaryAccount']
+    @uid = request.env['uid']
+    render 'sessions/subsidiary', status: :unauthorized
+  end
 end

--- a/app/views/sessions/subsidiary.html.haml
+++ b/app/views/sessions/subsidiary.html.haml
@@ -1,0 +1,11 @@
+%h1 Welcome to the website for Special Transportation.
+%h2 Subsidiary account:
+%p
+  You are attempting to login with #{@uid}, which is a role subsidiary account
+  belonging to #{@primary_account}. Role subsidiary accounts cannot be used to
+  access this site. Please login with your primary NetID. If you need
+  assistance, contact
+  = succeed '.' do
+    = mail_to 'transit-it@admin.umass.edu'
+
+= link_to 'Logout', destroy_session_path

--- a/app/views/sessions/subsidiary.html.haml
+++ b/app/views/sessions/subsidiary.html.haml
@@ -1,4 +1,4 @@
-%h1 Welcome to the website for Special Transportation.
+%h1 Welcome to the website for UMass Transit On-Call.
 %h2 Subsidiary account:
 %p
   You are attempting to login with #{@uid}, which is a role subsidiary account


### PR DESCRIPTION
Closes #205.

I tried to right a request spec for this, but it turns out setting a `request.env` var is a pain. You can pass `env: { uid: 12 }` to the `get` method, but it merges that env var into the Rack env hash. That auto-prefixes it so it ends up as `HTTP_UID`.