### PR TITLE
Allow subsidiary accounts on session routes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  skip_before_action :set_current_user, :set_roster
+  skip_before_action :check_primary_account, :set_current_user, :set_roster
 
   def destroy
     session.clear


### PR DESCRIPTION
I discovered today, when testing something else, that the ["Logout" link](https://github.com/umts/screaming-dinosaur/blob/7d284d9f5bd70216971e5aa162cb134da98f64e8/app/views/sessions/subsidiary.html.haml#L11) that we offer subsidiary accounts, when someone mistakenly logs in with one, didn't work because that same filter stops them from getting to `/sessions/destroy`, too.