### PR TITLE
Fix test failure after 8pm

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module ScreamingDinosaur
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.time_zone = 'Eastern Time (US & Canada)'
+
     config.on_call = config_for(:on_call)
   end
 end


### PR DESCRIPTION
My _browser_ is in the EDT time zone. But in UTC it's already tomorrow. So `Time.zone.today.day` returns a different number than the calendar on the site.

Failing test locally:

https://github.com/umts/screaming-dinosaur/blob/1ba508a7fb5d812626a2ab11c5e1b36444bbf0fd/spec/system/assignment/index_spec.rb#L39-L43