### PR TITLE
Switch from webdrivers to just using selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ group :test do
   gem 'rack_session_access'
   gem 'rails-controller-testing'
   gem 'rspec-html-matchers'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'timecop'
   gem 'umts-custom-matchers'
-  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,8 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
@@ -96,15 +96,15 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-yarn (2.0.2)
       capistrano (~> 3.0)
-    capybara (3.35.3)
+    capybara (3.39.2)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (4.1.0)
     chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -168,9 +168,10 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     mysql2 (0.5.3)
     net-http (0.2.2)
@@ -203,7 +204,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.6)
+    public_suffix (5.0.3)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -251,7 +252,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    regexp_parser (2.6.0)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
@@ -312,8 +313,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.5.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -348,10 +348,6 @@ GEM
       rspec-rails (>= 3.0, <= 6.0)
     unicode-display_width (2.3.0)
     uri (0.12.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -401,12 +397,12 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sassc-rails
+  selenium-webdriver
   simplecov
   sprockets-rails
   terser
   timecop
   umts-custom-matchers
-  webdrivers
   whenever
 
 RUBY VERSION


### PR DESCRIPTION
The internet tells me that new Selenium can manage your webdriver for you, too. This version doesn't know about the new download location for chromedriver 115 either, but it can download 114 and use that with Chrome 115.

This is an alternative to #289, and if Travis builds it successfully, I would say it's preferable.