### PR TITLE
Generate by weekday

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -5,8 +5,8 @@ require 'assignments_ics'
 class AssignmentsController < ApplicationController
   before_action :find_assignment, only: %i[destroy edit update]
   before_action :set_roster_users, only: %i[edit new rotation_generator]
-  before_action :require_admin_in_roster, only: %i[generate_rotation
-                                                   rotation_generator]
+  before_action :require_admin_in_roster, only: %i[generate_rotation rotation_generator
+                                                   generate_by_weekday generate_by_weekday_submit]
   skip_before_action :set_current_user, :set_roster, only: :feed
 
   def index

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -43,6 +43,22 @@ class AssignmentsController < ApplicationController
     redirect_to roster_assignments_path(@roster, date: start_date)
   end
 
+  def generate_by_weekday
+    @generator = Assignment::WeekdayGenerator.new roster_id: @roster.id
+  end
+
+  def generate_by_weekday_submit
+    @generator = Assignment::WeekdayGenerator.new(roster_id: @roster.id,
+                                                  **generate_by_weekday_params)
+    if @generator.generate
+      flash[:message] = t('.success')
+      redirect_to roster_assignments_path(@roster, date: @generator.start_date)
+    else
+      flash.now[:errors] = @generator.errors.full_messages.to_sentence
+      render :generate_by_weekday
+    end
+  end
+
   def create
     ass_params = params.require(:assignment)
                        .permit :start_date, :end_date,
@@ -157,5 +173,9 @@ class AssignmentsController < ApplicationController
   def taking_ownership?
     new_user_id = params.require(:assignment).require(:user_id)
     new_user_id == @current_user.id.to_s
+  end
+
+  def generate_by_weekday_params
+    params.fetch(:assignment_weekday_generator, {}).permit!
   end
 end

--- a/app/views/assignments/generate_by_weekday.html.haml
+++ b/app/views/assignments/generate_by_weekday.html.haml
@@ -1,0 +1,27 @@
+%section.container.my-3
+  %h1 Generate by Weekday
+  %hr
+  = form_with model: @generator,
+              url: generate_by_weekday_submit_roster_assignments_path(@roster),
+              local: true do |f|
+    .form-group
+      = f.label :user_id
+      = f.collection_select :user_id, @roster.users.active.order(:last_name), :id, :last_name,
+                            { include_blank: true }, class: 'custom-select'
+    .form-row
+      .form-group.col-md
+        = f.label :start_date
+        = f.date_field :start_date, class: 'form-control'
+      .form-group.col-md
+        = f.label :end_date
+        = f.date_field :end_date, class: 'form-control'
+    .form-row
+      .form-group.col-md
+        = f.label :start_weekday
+        = f.collection_select :start_weekday, Date::DAYNAMES, ->(day) { Date::DAYNAMES.index(day) }, :itself,
+                              {}, required: true, class: 'custom-select'
+      .form-group.col-md
+        = f.label :end_weekday
+        = f.collection_select :end_weekday, Date::DAYNAMES, ->(day) { Date::DAYNAMES.index(day) }, :itself,
+                              {}, required: true, class: 'custom-select'
+    = f.submit 'Generate', class: 'btn btn-primary'

--- a/app/views/layouts/_nav.haml
+++ b/app/views/layouts/_nav.haml
@@ -13,8 +13,13 @@
           = nav_link_item 'Manage Rosters', rosters_path
           - if @current_user&.admin_in? @roster
             = nav_link_item 'Manage Users', roster_users_path(@roster)
-            = nav_link_item 'Generate Rotation',
-              rotation_generator_roster_assignments_path(@roster)
+            %li.nav-item.dropdown
+              = link_to 'Generate', '#', role: 'button',
+                        id: 'navbar-generate-nav-link', class: 'nav-link dropdown-toggle',
+                        'data-toggle': 'dropdown', 'aria-expanded': 'false'
+              .dropdown-menu{ 'aria-labelledby': 'navbar-generate-nav-link' }
+                = link_to 'Rotation', rotation_generator_roster_assignments_path(@roster), class: 'dropdown-item'
+                = link_to 'By Weekday', generate_by_weekday_roster_assignments_path(@roster), class: 'dropdown-item'
       %ul.navbar-nav
         - if @current_user.present?
           %li.nav-item.navbar-text.mx-2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,3 +45,5 @@ en:
                     Or, a roster administrator can perform this change for you.'
     destroy:
       not_an_admin: 'Only roster admins may delete assignments.'
+    generate_by_weekday_submit:
+      success: "Assignments have been generated."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
       collection do
         post :generate_rotation
         get  :rotation_generator
+        get :generate_by_weekday
+        post :generate_by_weekday_submit
       end
     end
 


### PR DESCRIPTION
A specialized assignment generation tool to be used to setup a "signup" type scaffold over a long date range with weekday based shifts. No testing... yet

