### PR TITLE
Fix Bootstrap data attributes on Toggler

### DIFF
--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -1,7 +1,7 @@
 %nav.navbar.navbar-expand-lg.navbar-dark.bg-primary.mb-2
   .container-fluid
     %button.navbar-toggler{ type: 'button',
-      'data-bs': { toggle: 'collapse', target: '#navCollapse' },
+      data: { bs_toggle: 'collapse', bs_target: '#navCollapse' },
       aria: { controlls: '#navCollapse', expanded: 'false', label: 'Toggle navigation' } }
       %span.navbar-toggler-icon
     #navCollapse.collapse.navbar-collapse.mb-2.mb-lg-0


### PR DESCRIPTION
Only `data` and `aria` auto-expand hashes into mutliple HTML attributes. Before this fix, this made one attribute called "data-bs" with a value of `'{:toggle=&gt;&quot;collapse&quot;, :target=&gt;&quot;#navCollapse&quot;}'`.