### PR TITLE
Fix roster upcoming

### DIFF
--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -16,6 +16,7 @@ class RostersController < ApplicationController
   end
 
   def show
+    @upcoming = @roster.assignments.upcoming.order(:start_date)
     respond_to do |format|
       format.json { render layout: false }
     end

--- a/app/views/rosters/show.json.jbuilder
+++ b/app/views/rosters/show.json.jbuilder
@@ -9,8 +9,8 @@ if (user = @roster.on_call_user).present?
 else
   json.on_call nil
 end
-if (upcoming = @roster.assignments.upcoming.sort_by(&:start_date)).present?
+if @upcoming.present?
   json.upcoming do
-    json.extract! upcoming.first&.user, :last_name, :first_name
+    json.extract! @upcoming.first.user, :last_name, :first_name
   end
 end

--- a/app/views/rosters/show.json.jbuilder
+++ b/app/views/rosters/show.json.jbuilder
@@ -9,7 +9,7 @@ if (user = @roster.on_call_user).present?
 else
   json.on_call nil
 end
-if (upcoming = @roster.assignments.upcoming).present?
+if (upcoming = @roster.assignments.upcoming.sort_by(&:start_date)).present?
   json.upcoming do
     json.extract! upcoming.first&.user, :last_name, :first_name
   end


### PR DESCRIPTION
Pires mentioned that it "wasn't working". I think the reason is because the assignments weren't being pulled in order of start date, so it wasn't getting the right "next" one. I don't have an account on prod so I verified this by playing around in the console, and I played around in dev trying to reproduce and I think I was able to, and this at least fixes that.