### PR TITLE
Add HamlLint to Overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -9,6 +9,11 @@ PreCommit:
   ForbiddenBranches:
     enabled: true
     branch_patterns: ["master", "main"]
+  HamlLint:
+    enabled: true
+    on_warn: fail
+    required_executable: bundle
+    command: ["bundle", "exec", "haml-lint"]
   RuboCop:
     enabled: true
     required_executable: bundle


### PR DESCRIPTION
Closes #440, I guess?

@benmelz, not sure what you ran into in #431, but `haml-lint` is [in the `Gemfile`](https://github.com/umts/screaming-dinosaur/blob/91918342d23c2a8544aea2b4a2bd190dbf9b724a/Gemfile#L36). This _seems_ to work OK for me?