### PR TITLE
Removed All Occurrences of redirect_back and report_errors from RosterController

### DIFF
--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -4,7 +4,6 @@ class RostersController < ApplicationController
   api_accessible only: :show
 
   before_action :find_roster, only: %i[destroy edit setup show update]
-  before_action :find_users, only: %i[update]
   before_action :require_admin, except: %i[assignments show]
   before_action :require_admin_in_roster, only: %i[destroy edit setup update]
 
@@ -23,9 +22,7 @@ class RostersController < ApplicationController
     end
   end
 
-  def edit
-    @users = @roster.users
-  end
+  def edit; end
 
   def create
     @roster = Roster.new roster_params
@@ -63,10 +60,6 @@ class RostersController < ApplicationController
 
   def find_roster
     @roster = Roster.friendly.find params.require(:id)
-  end
-
-  def find_users
-    @users = @roster.users
   end
 
   def roster_params

--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -27,15 +27,16 @@ class RostersController < ApplicationController
   end
 
   def create
-    roster = Roster.new roster_params
+    @roster = Roster.new roster_params
     # Current user becomes admin in new roster
-    roster.users << Current.user
-    roster.memberships.first.update admin: true
-    if roster.save
-      confirm_change(roster)
+    @roster.users << Current.user
+    @roster.memberships.first.update admin: true
+    if @roster.save
+      confirm_change(@roster)
       redirect_to rosters_path
     else
-      report_errors(roster, fallback_location: rosters_path)
+      flash.now[:errors] = @roster.errors.full_messages
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -44,7 +45,8 @@ class RostersController < ApplicationController
       confirm_change(@roster)
       redirect_to rosters_path
     else
-      report_errors(@roster, fallback_location: rosters_path)
+      flash.now[:errors] = @roster.errors.full_messages
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/rosters_controller.rb
+++ b/app/controllers/rosters_controller.rb
@@ -4,6 +4,7 @@ class RostersController < ApplicationController
   api_accessible only: :show
 
   before_action :find_roster, only: %i[destroy edit setup show update]
+  before_action :find_users, only: %i[update]
   before_action :require_admin, except: %i[assignments show]
   before_action :require_admin_in_roster, only: %i[destroy edit setup update]
 
@@ -62,6 +63,10 @@ class RostersController < ApplicationController
 
   def find_roster
     @roster = Roster.friendly.find params.require(:id)
+  end
+
+  def find_users
+    @users = @roster.users
   end
 
   def roster_params

--- a/app/views/rosters/edit.html.haml
+++ b/app/views/rosters/edit.html.haml
@@ -9,7 +9,7 @@
     = f.phone_field :phone, class: 'form-control'
   .mb-3
     = f.label :fallback_user, class: 'form-label'
-    = f.collection_select :fallback_user_id, @users, :id, :last_name,
+    = f.collection_select :fallback_user_id, @roster.users, :id, :last_name,
       { include_blank: true }, class: 'form-select'
   .mb-3
     = f.label :switchover_time, class: 'form-label'

--- a/spec/controllers/rosters_controller_spec.rb
+++ b/spec/controllers/rosters_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe RostersController do
         user2 = roster_user roster
         user3 = roster_user roster
         submit
-        expect(assigns.fetch(:users)).to include user1, user2, user3
+        expect(assigns.fetch(:roster).users).to include user1, user2, user3
       end
 
       it 'renders the edit template' do

--- a/spec/controllers/rosters_controller_spec.rb
+++ b/spec/controllers/rosters_controller_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe RostersController do
           expect(flash[:errors]).not_to be_empty
         end
 
-        it 'redirects back' do
-          expect { submit }.to redirect_back
+        it 'returns to the new template' do
+          submit
+          expect(response).to have_http_status :unprocessable_entity
         end
       end
     end
@@ -237,8 +238,9 @@ RSpec.describe RostersController do
           expect(flash[:errors]).not_to be_empty
         end
 
-        it 'and redirects back' do
-          expect { submit }.to redirect_back
+        it 'stays on the edit page' do
+          submit
+          expect(response).to have_http_status :unprocessable_entity
         end
       end
     end


### PR DESCRIPTION
Continuation of #423 

Removed all occurrences of `redirect_back` and `report_errors` from `RosterController` and the specs. `create` and `update` now re-render `:new` and `:edit` on failure with an `:uprocessable_entity` status. The specs that checked for a `redirect_back` now look for that status.

I noticed that `destroy` does not have any checks for errors besides `require_admin_in_roster`. All the other controllers have some form of a catch for errors when destroying. I'll create a small PR and add it after this one.