### PR TITLE
Removed All Occurrences of redirect_back from UsersController

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,7 +41,7 @@ class UsersController < ApplicationController
       end
     else
       flash.now[:errors] = @user.errors.full_messages
-      render 'edit'
+      render :edit
     end
   end
 
@@ -51,7 +51,8 @@ class UsersController < ApplicationController
       confirm_change(@user, "Added #{@user.full_name} to roster.")
       redirect_to roster_users_path(@roster)
     else
-      report_errors(@user, fallback_location: roster_users_path)
+      flash.now[:errors] = @user.errors.full_messages
+      render :index, status: :unprocessable_entity
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -279,7 +279,8 @@ RSpec.describe UsersController do
         end
 
         it 'redirects back' do
-          expect { submit }.to redirect_back
+          submit
+          expect(response).to have_http_status :unprocessable_entity
         end
 
         it 'shows errors' do


### PR DESCRIPTION
Continuation of #423 

Removed all occurrences of `redirect_back` and `report_errors` from `UsersController` and the specs. Actions now render the forms again and flash error messages.