### PR TITLE
ChangesController Spec Does Not Use Redirect_Back

### DIFF
--- a/spec/controllers/changes_controller_spec.rb
+++ b/spec/controllers/changes_controller_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe ChangesController do
           expect { assignment.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
 
-        it 'redirects back' do
-          expect { submit }.to redirect_back
+        it 'redirects' do
+          submit
+          expect(response).to have_http_status :redirect
         end
 
         it 'informs you of success' do
@@ -47,8 +48,9 @@ RSpec.describe ChangesController do
           expect { assignment.reload }.not_to raise_error
         end
 
-        it 'redirects back' do
-          expect { submit }.to redirect_back
+        it 'redirects' do
+          submit
+          expect(response).to have_http_status :redirect
         end
       end
 
@@ -68,8 +70,9 @@ RSpec.describe ChangesController do
           expect(assignment.reload.start_date).to eql original_start_date
         end
 
-        it 'redirects back' do
-          expect { submit }.to redirect_back
+        it 'redirects' do
+          submit
+          expect(response).to have_http_status :redirect
         end
       end
     end

--- a/spec/controllers/changes_controller_spec.rb
+++ b/spec/controllers/changes_controller_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe ChangesController do
   describe 'GET #undo', :versioning do
     let(:change_user) { create :user }
     let(:assignment) { create :assignment }
+    let(:redirect_target) { '/redirect_to_me' }
 
     context 'when the change is made by user' do
-      before { when_current_user_is change_user }
+      before do
+        when_current_user_is change_user
+        request.env['HTTP_REFERER'] = redirect_target
+      end
 
       context 'when the version is a "create" version' do
         subject(:submit) { get :undo, params: { id: version.id } }
@@ -25,7 +29,7 @@ RSpec.describe ChangesController do
 
         it 'redirects' do
           submit
-          expect(response).to have_http_status :redirect
+          expect(response).to redirect_to redirect_target
         end
 
         it 'informs you of success' do
@@ -50,7 +54,7 @@ RSpec.describe ChangesController do
 
         it 'redirects' do
           submit
-          expect(response).to have_http_status :redirect
+          expect(response).to redirect_to redirect_target
         end
       end
 
@@ -72,7 +76,7 @@ RSpec.describe ChangesController do
 
         it 'redirects' do
           submit
-          expect(response).to have_http_status :redirect
+          expect(response).to redirect_to redirect_target
         end
       end
     end


### PR DESCRIPTION
More of #423 

The `ChangesController` spec no longer uses `redirect_back`. Instead, it just checks for the `:redirected` status.