### PR TITLE
Removed umts-custom-matchers Gem and ApplicationController#report_errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,5 +61,4 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'timecop'
-  gem 'umts-custom-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,8 +368,6 @@ GEM
     timeout (0.4.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    umts-custom-matchers (2.0.0)
-      rspec-rails (>= 3.0, <= 6.0)
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -434,7 +432,6 @@ DEPENDENCIES
   sprockets-rails
   terser
   timecop
-  umts-custom-matchers
   whenever
 
 RUBY VERSION

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,11 +30,6 @@ class ApplicationController < ActionController::Base
     # rubocop:enable Rails/ActionControllerFlashBeforeRender
   end
 
-  def report_errors(object, fallback_location:)
-    flash[:errors] = object.errors.full_messages
-    redirect_back fallback_location:
-  end
-
   # There are three levels of access:
   # 1. Regular users
   # 2. Admins in general (of any roster)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'rack_session_access/capybara'
-require 'umts_custom_matchers'
 require 'paper_trail/frameworks/rspec'
 
 ActiveRecord::Migration.maintain_test_schema!
@@ -22,7 +21,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include FactoryBot::Syntax::Methods
-  config.include UmtsCustomMatchers
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Closes #423 

Removed `umts-custom-matchers` from the `Gemfile` and `spec_helper`. Also removed `ApplicationController#report_errors` since that was no longer used. 