### PR TITLE
Don't use system libraries to build Nokogiri

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,5 +3,3 @@
 server 'af-transit-app3.admin.umass.edu',
        roles: %w[app db web],
        ssh_options: { forward_agent: false }
-
-set :bundle_env_variables, { 'NOKOGIRI_USE_SYSTEM_LIBRARIES' => 1 }


### PR DESCRIPTION
We're _not_ building Nokogiri, and in this case, we _could_ with system libraries because Ubuntu has slightly newer libxml2. But, we definitely don't need to.