### PR TITLE
Fix CSV export when using friendly-id slugged ids

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -13,7 +13,7 @@ class AssignmentsController < ApplicationController
       format.ics { render_ics_feed }
       format.json { index_json }
       format.csv do
-        @roster = Roster.preload(assignments: :user).find(params[:roster_id])
+        @roster = Roster.preload(assignments: :user).friendly.find(params[:roster_id])
         render csv: @roster.assignment_csv, filename: @roster.name
       end
     end


### PR DESCRIPTION
@sherson asks for an "Admin CSV" in August of 2023 (#299), gets it. Then Matt breaks it 1 week later (#308) - remains broken for two years.