### PR TITLE
Configure npm with engine-strict=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
By default npm will _warn_ about engine incompatibilities but won't refuse to install them. This puts a stopper in that.

I'm mainly nervous that someone one way will see one of the eslint/stylelint upgrade PRs, see a green check and merge them. I'm _also_ considering writing to this file within the shared rails ci workflow, since that'll cover all the apps without having to explicitly check this in... but would like to hear opinions on that.

