### PR TITLE
Fix failures with more than one 14th

### DIFF
--- a/spec/system/assignment/index_spec.rb
+++ b/spec/system/assignment/index_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'viewing the index' do
       it 'sends you to create a new assignment' do
         visit roster_assignments_path(roster)
 
-        find('td.fc-day', text: '14').click
+        find('td.fc-day:not(.fc-day-other)', text: '14').click
         expect(page).to have_current_path(new_path)
       end
     end


### PR DESCRIPTION
February 2026 is a "perfect month", which means all of its days fit on 4 lines of a calendar, leaving room for _two_ of the next month's weeks in FullCalendar's six rows. Which means there's two possible 14ths to click on.