### PR TITLE
Add task to fill dummy entra uids

### DIFF
--- a/app/tasks/maintenance/fill_missing_entra_uids_task.rb
+++ b/app/tasks/maintenance/fill_missing_entra_uids_task.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# :nocov:
+module Maintenance
+  class FillMissingEntraUidsTask < MaintenanceTasks::Task
+    def collection
+      User.where(entra_uid: nil)
+    end
+
+    def process(user)
+      user.update!(entra_uid: "missing-#{user.spire.delete_suffix('@umass.edu')}")
+    end
+  end
+end
+# :nocov:


### PR DESCRIPTION
There are a couple of people that have since been removed from AD completely, as well as the dummy "open" users.

As we need something to put in the column, I figured it wouldn't hurt to retain spire ids, as well as use a common prefix (`missing-`).

