### PR TITLE
anchor assignment start datetimes

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -8,7 +8,9 @@ class Assignment < ApplicationRecord
   belongs_to :roster
   belongs_to :user, optional: true
 
-  validates :end_datetime, presence: true, uniqueness: { scope: :roster_id }
+  validates :end_datetime, presence: true, uniqueness: { scope: :roster_id },
+                           comparison: { greater_than: ->(assignment) { assignment.roster&.created_at },
+                                         message: :must_be_after_roster_created_at }
 
   scope :ending_before, ->(time) { where(arel_table[:end_datetime].lt(time)) }
   scope :ending_after, ->(time) { where(arel_table[:end_datetime].gt(time)) }
@@ -21,7 +23,10 @@ class Assignment < ApplicationRecord
 
   class << self
     def with_start_datetimes
-      from arel_table.project(arel_table[Arel.star], start_datetime_node).as(arel_table.name)
+      rosters = Roster.arel_table
+      inner = arel_table.join(rosters).on(rosters[:id].eq(arel_table[:roster_id]))
+                        .project(arel_table[Arel.star], start_datetime_node)
+      from inner.as(arel_table.name)
     end
 
     def to_csv # rubocop:disable Metrics
@@ -46,7 +51,9 @@ class Assignment < ApplicationRecord
 
     def start_datetime_node
       Arel::Nodes::Over.new(
-        Arel::Nodes::NamedFunction.new('LAG', [arel_table[:end_datetime]]),
+        Arel::Nodes::NamedFunction.new('LAG', [arel_table[:end_datetime],
+                                               Arel::Nodes.build_quoted(1),
+                                               Roster.arel_table[:created_at]]),
         Arel::Nodes::Window.new.partition(arel_table[:roster_id]).order(arel_table[:end_datetime])
       ).as(arel_table[:start_datetime].name)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
       may_not_deactivate_self: "You may not deactivate yourself"
       must_be_fc_id_number: "must be 8 digits followed by @umass.edu"
       must_be_in_selected_users: "must be included in the list of selected users"
+      must_be_after_roster_created_at: "must be after the roster was created"
       must_not_be_before_start: "must not be before start"
   date:
     formats:

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe Assignment do
 
     it { is_expected.to validate_presence_of(:end_datetime) }
     it { is_expected.to validate_uniqueness_of(:end_datetime).scoped_to(:roster_id) }
+
+    describe 'end_datetime relative to the roster create datetime' do
+      let(:roster) { create :roster }
+
+      it 'is invalid when before the roster create datetime' do
+        assignment = build(:assignment, roster:, end_datetime: 1.second.before(roster.created_at))
+        expect(assignment).not_to be_valid
+      end
+
+      it 'is invalid when equal to the roster create datetime' do
+        assignment = build(:assignment, roster:, end_datetime: roster.created_at)
+        expect(assignment).not_to be_valid
+      end
+
+      it 'is valid when after the roster create datetime' do
+        assignment = build(:assignment, roster:, end_datetime: 1.second.after(roster.created_at))
+        expect(assignment).to be_valid
+      end
+    end
   end
 
   describe '#previous' do
@@ -113,7 +132,7 @@ RSpec.describe Assignment do
   describe '.with_start_datetimes' do
     subject(:call) { described_class.with_start_datetimes }
 
-    let(:time) { Time.current }
+    let(:time) { 1.hour.from_now }
     let(:rosters) { create_list :roster, 2 }
     let!(:roster_one_assignments) do
       [1.minute.after(time), 1.minute.before(time), 3.minutes.before(time)].map do |end_datetime|
@@ -133,13 +152,13 @@ RSpec.describe Assignment do
     it 'preloads start datetimes at the database level and writes them to attributes' do
       expect(call.collect(&:attributes)).to contain_exactly(
         a_hash_including('id' => roster_one_assignments.first.id,
-                         'start_datetime' => nil),
+                         'start_datetime' => rosters.first.created_at),
         a_hash_including('id' => roster_one_assignments.second.id,
                          'start_datetime' => roster_one_assignments.first.end_datetime),
         a_hash_including('id' => roster_one_assignments.third.id,
                          'start_datetime' => roster_one_assignments.second.end_datetime),
         a_hash_including('id' => roster_two_assignments.first.id,
-                         'start_datetime' => nil),
+                         'start_datetime' => rosters.second.created_at),
         a_hash_including('id' => roster_two_assignments.second.id,
                          'start_datetime' => roster_two_assignments.first.end_datetime),
         a_hash_including('id' => roster_two_assignments.third.id,

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'Assignments' do
     context 'when logged in as a member of the roster' do
       include_context 'when logged in as a member of the roster'
 
+      let(:roster) { create :roster, created_at: 2.days.ago.middle_of_day }
       let!(:past_assignment) { create :assignment, roster:, end_datetime: Date.yesterday.at_middle_of_day }
       let!(:open_assignment) { create :assignment, roster:, end_datetime: Date.current.at_middle_of_day }
       let!(:taken_assignment) do


### PR DESCRIPTION
Closes the two model-only items on the #950 checklist:                                                                                                                                                                                            - Adds a validation that an assignment's `end_datetime` must be after its roster's `created_at`. Without this, the LAG anchor below would be a meaningless point in time.  
- Passes `rosters.created_at` as the third argument to the `LAG()` window function in `Assignment.with_start_datetimes`, so the first assignment per roster resolves to a real `start_datetime` instead of `NULL`. The subquery now joins `rosters` so the column is in scope.                                                                              
                                  