### PR TITLE
Remove user from future assignments with datetime on membership destroy

### DIFF
--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe Membership do
       let(:membership) { create :membership }
       let!(:past_assignments) do
         [create(:assignment, roster: membership.roster, user: membership.user,
-                             start_date: 4.days.ago, end_date: 3.days.ago),
+                             end_datetime: 3.days.ago),
          create(:assignment, roster: membership.roster, user: membership.user,
-                             start_date: 2.days.ago, end_date: 1.day.ago)]
+                             end_datetime: 1.day.ago)]
       end
       let!(:future_assignments) do
         [create(:assignment, roster: membership.roster, user: membership.user,
-                             start_date: Date.tomorrow, end_date: 2.days.from_now),
+                             end_datetime: 2.days.from_now),
          create(:assignment, roster: membership.roster, user: membership.user,
-                             start_date: 3.days.from_now, end_date: 4.days.from_now)]
+                             end_datetime: 4.days.from_now)]
       end
 
       it 'leaves past assignment untouched for the associated user and roster' do
@@ -37,9 +37,9 @@ RSpec.describe Membership do
         expect(past_assignments.map { |assignment| Assignment.find_by(id: assignment.id) }).to all(be_present)
       end
 
-      it 'destroys all future assignments for the associated user and roster' do
+      it 'removes the user from all future assignments for the associated user and roster' do
         call
-        expect(future_assignments.map { |assignment| Assignment.find_by(id: assignment.id) }).to all(be_nil)
+        expect(future_assignments.map { |assignment| assignment.reload.user }).to all(be_nil)
       end
     end
   end


### PR DESCRIPTION
Changes date to datetime.
Updates test to nullify user on future assignments on membership destroy.