### PR TITLE
Rewrite seeds for datetime assignments

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,8 @@ exit unless Rails.env.development?
 
 # ROTATIONS
 transit_it = FactoryBot.create :roster, name: 'Transit IT', created_at: Time.current.beginning_of_week(:friday)
-ops = FactoryBot.create :roster, name: 'Transit Operations', created_at: Time.current.beginning_of_week(:friday)
+ops = FactoryBot.create :roster, name: 'Transit Operations',
+                                 created_at: Time.current.beginning_of_week(:friday).change(hour: 4, min: 30)
 
 # USERS
 names = {
@@ -35,32 +36,30 @@ names = {
   ]
 }
 
+admins = {
+  transit_it => %w[Sherson],
+  ops => %w[Barrington Noble]
+}
+
 names.each_pair do |roster, rot_names|
   rot_names.each do |first_name, last_name|
-    user = User.find_by first_name: first_name, last_name: last_name
-    if user.present?
-      user.rosters << roster
-      user.save!
-    else
-      FactoryBot.create :user, first_name: first_name,
-                               last_name: last_name, rosters: [roster]
-    end
+    user = User.find_by(first_name: first_name, last_name: last_name) ||
+           FactoryBot.create(:user, first_name: first_name, last_name: last_name)
+    FactoryBot.create :membership, roster: roster, user: user,
+                                   admin: admins[roster].include?(last_name)
   end
 end
 
 # ADMINS
-ops.memberships.joins(:user).where(users: { last_name: %w[Barrington Noble] })
-   .update_all admin: true # rubocop:disable Rails/SkipsModelValidations
-transit_it.memberships.joins(:user).where(users: { last_name: 'Sherson' })
-          .update_all admin: true # rubocop:disable Rails/SkipsModelValidations
-User.find_by(last_name: 'Sherson').update(admin: true)
+User.find_by(last_name: 'Sherson').update admin: true
 
 # ASSIGNMENTS
-unless ENV['SKIP_ASSIGNMENTS']
-  Roster.find_each do |roster|
-    roster.users.order(:last_name).each_with_index do |user, i|
-      FactoryBot.create :assignment, user: user, roster: roster,
-                                     end_datetime: (i + 1).weeks.since.beginning_of_week(:friday)
-    end
-  end
+transit_it.users.order(:last_name).each_with_index do |user, i|
+  FactoryBot.create :assignment, user: user, roster: transit_it,
+                                 end_datetime: (i + 1).weeks.since.beginning_of_week(:friday)
+end
+
+ops.users.order(:last_name).cycle.take(70).each_with_index do |user, i|
+  FactoryBot.create :assignment, user: user, roster: ops,
+                                 end_datetime: ops.created_at + ((i + 1) * 12).hours
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,8 +60,7 @@ unless ENV['SKIP_ASSIGNMENTS']
   Roster.find_each do |roster|
     roster.users.order(:last_name).each_with_index do |user, i|
       FactoryBot.create :assignment, user: user, roster: roster,
-                                     start_date: i.weeks.since.beginning_of_week(:friday),
-                                     end_date: i.weeks.since.end_of_week(:friday)
+                                     end_datetime: (i + 1).weeks.since.beginning_of_week(:friday)
     end
   end
 end


### PR DESCRIPTION
Fixes the seeds assignments loop for the datetime refactor — assignments no longer have start_date/end_date, so `rails db:seed` crashed there. Each user now gets an end_datetime of `(i + 1).weeks.since.beginning_of_week(:friday)`, which reproduces the old Friday-to-Friday weekly rotation since start times derive from the previous assignment's end (or the roster's created_at for the first).