### PR TITLE
Restrict assignment management to roster admins

### DIFF
--- a/app/policies/assignment_policy.rb
+++ b/app/policies/assignment_policy.rb
@@ -3,14 +3,7 @@
 class AssignmentPolicy < ApplicationPolicy
   authorize :roster, optional: true
 
-  def manage?
-    allowed_to?(:manage?,
-                record.roster) || (allowed_to?(:show?, record.roster) && record.user_id == user.id)
-  end
+  def manage? = allowed_to?(:manage?, record.roster)
 
   def index? = allowed_to?(:show?, roster)
-
-  def new? = allowed_to?(:show?, record.roster)
-
-  def edit? = allowed_to?(:show?, record.roster)
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -7,7 +7,10 @@ class UserPolicy < ApplicationPolicy
 
   def show_auth? = false
 
-  def create? = request.session[:entra_uid].present? && user.blank? && no_access_changes?
+  def create?
+    request.session[:entra_uid].present? && user.blank? && no_access_changes? &&
+      record.entra_uid == request.session[:entra_uid]
+  end
 
   def update?
     return false unless no_access_changes? || allowed_to?(:update_access?, record)

--- a/spec/requests/assignments_spec.rb
+++ b/spec/requests/assignments_spec.rb
@@ -199,6 +199,15 @@ RSpec.describe 'Assignments' do
     context 'when logged in as a member of the roster' do
       include_context 'when logged in as a member of the roster'
 
+      it 'responds with a forbidden status' do
+        call
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as an admin of the roster' do
+      include_context 'when logged in as an admin of the roster'
+
       it 'responds successfully' do
         call
         expect(response).to be_successful
@@ -223,6 +232,15 @@ RSpec.describe 'Assignments' do
 
     context 'when logged in as a member of the roster' do
       include_context 'when logged in as a member of the roster'
+
+      it 'responds with a forbidden status' do
+        call
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when logged in as an admin of the roster' do
+      include_context 'when logged in as an admin of the roster'
 
       it 'responds successfully' do
         call
@@ -250,25 +268,6 @@ RSpec.describe 'Assignments' do
       include_context 'when logged in as a member of the roster'
 
       let(:attributes) { { user_id: current_user.id, end_datetime: Time.zone.tomorrow.middle_of_day } }
-
-      it 'redirects to the roster' do
-        submit
-        expect(response).to redirect_to roster_path(roster)
-      end
-
-      it 'creates a new assignment' do
-        expect { submit }.to change(Assignment, :count).by(1)
-      end
-
-      it 'creates a new assignment with the given attributes' do
-        submit
-        expect(Assignment.last).to have_attributes(attributes.merge('roster_id' => roster.id))
-      end
-    end
-
-    context 'when logged in as a member of the roster assigning someone else' do
-      include_context 'when logged in as a member of the roster'
-      include_context 'with valid attributes'
 
       it 'responds with a forbidden status' do
         submit
@@ -326,37 +325,6 @@ RSpec.describe 'Assignments' do
       include_context 'when logged in as a member of the roster'
 
       let(:attributes) { { user_id: current_user.id } }
-
-      it 'redirects to the roster' do
-        submit
-        expect(response).to redirect_to roster_path(roster)
-      end
-
-      it 'creates a new assignment' do
-        expect { submit }.to change(Assignment, :count).by(1)
-      end
-
-      it 'creates a new assignment with the given attributes' do
-        submit
-        expect(Assignment.last).to have_attributes(attributes.merge('roster_id' => roster.id))
-      end
-    end
-
-    context 'when logged in as a member of the roster assigning someone else' do
-      include_context 'when logged in as a member of the roster'
-
-      let(:attributes) { { user_id: create(:user, rosters: [roster]).id } }
-
-      it 'responds with a forbidden status' do
-        submit
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context 'when logged in as a member of the roster changing dates' do
-      include_context 'when logged in as a member of the roster'
-
-      let(:attributes) { { end_datetime: Time.zone.tomorrow.middle_of_day } }
 
       it 'responds with a forbidden status' do
         submit

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -172,6 +172,26 @@ RSpec.describe 'Users' do
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
+
+    context 'when logged in as a registrant submitting a different entra_uid' do
+      let(:current_user) { User.new(entra_uid: 'new-user') }
+      let(:attributes) do
+        { first_name: 'Bobo',
+          last_name: 'Test',
+          email: 'bobo@test.com',
+          phone: '(413) 545-0056',
+          entra_uid: 'someone-elses-uid' }
+      end
+
+      it 'redirects to the registration page' do
+        submit
+        expect(response).to redirect_to(new_user_path)
+      end
+
+      it 'does not create a user' do
+        expect { submit }.not_to change(User, :count)
+      end
+    end
   end
 
   describe 'PATCH /users/:id' do


### PR DESCRIPTION
Restricts assignment CRUD to roster admins per #1113 — new/edit now fall through to manage, which drops the own-assignment exception. Members take shifts via the taker instead. Note destroy is included, so members can no longer give up their own shifts directly.

Flags from the wider audit: UserPolicy#create? does not pin entra_uid to the session (identity squatting); Twilio endpoints serve the on-call phone number unauthenticated (#772, intentional?); the taker lets members take already-assigned shifts.

Part of #1113.